### PR TITLE
fix: 비밀번호와 이메일이 일치하는 데 로그인이 되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/example/outsourcingproject/auth/service/OwnerAuthServiceImpl.java
+++ b/src/main/java/com/example/outsourcingproject/auth/service/OwnerAuthServiceImpl.java
@@ -47,7 +47,7 @@ public class OwnerAuthServiceImpl implements OwnerAuthService{
         // todo 로그인 상태가 아닌 사장만 들어올 수 있게 -> 필터
 
         // 탈퇴하지 않은 사장님들 중에서 이메일 값이 일치하는 사장님 추출
-        Owner owner = ownerAuthRepository.findByEmailAndIsDeleted(email, true)
+        Owner owner = ownerAuthRepository.findByEmailAndIsDeleted(email, false)
             .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
 
         String encodedPassword = owner.getPassword();


### PR DESCRIPTION
- 사장님을 데이터베이스에서 조회할 때 입력하는 삭제 여부 값을 true에서 false로 수정

- 손님을 데이터베이스에서 조회할 때 입력하는 삭제 여부 값은 false라서 버그가 발생하지 않음